### PR TITLE
(fix): use PAT for issue creation

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Report failure issue
-        if: failure() && env.issue_exists == 'false'
+        if: failure() && env.issue_exists == 'false' && github.event_name == 'schedule'
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ISSUE_BODY="The daily CI failed on ${failure_type} for ${{ matrix.package }} failed.  Please go to [the logs of the integration testing repo](${RUN_URL}) to review. @scverse/anndata"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Report failure issue
-        if: failure() && env.issue_exists == 'false' && github.event_name == 'schedule'
+        if: failure() && env.issue_exists == 'false'
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ISSUE_BODY="The daily CI failed on ${failure_type} for ${{ matrix.package }} failed.  Please go to [the logs of the integration testing repo](${RUN_URL}) to review. @scverse/anndata"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,7 +28,7 @@ jobs:
   
     env:
       # This env variable is used by the `gh` CLI
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.TOKEN_FOR_ISSUE_WRITE }}
 
     steps:
 
@@ -79,7 +79,7 @@ jobs:
           echo "failure_type=test" >> $GITHUB_ENV
     
       - name: Check for open failure issue
-        if: failure() && github.event_name == 'schedule'
+        if: failure()
         id: find_issue
         run: |
           ISSUE_TITLE="Integration Testing CI ${failure_type^} Failure on python ${{ matrix.python }}"
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Report failure issue
-        if: failure() && env.issue_exists == 'false' && github.event_name == 'schedule'
+        if: failure() && env.issue_exists == 'false'
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ISSUE_BODY="The daily CI failed on ${failure_type} for ${{ matrix.package }} failed.  Please go to [the logs of the integration testing repo](${RUN_URL}) to review. @scverse/anndata"


### PR DESCRIPTION
See https://github.com/orgs/community/discussions/46566

I don't know if this applies to us, since we are public, but the fact that the token did not seem to work for the currently failing jobs and that the permissions explicitly state:

<img width="448" alt="Screenshot 2024-12-03 at 14 32 19" src="https://github.com/user-attachments/assets/7e265a90-d4e7-4868-8253-fac176aee7da">

and there is no other option for `public_repo` which is what is needed to make this work