### PR TITLE
Add pertpy to test matrix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.11", "3.12"]
-        package: ["mudata", "spatialdata", "scirpy", "muon", "scanpy", "squidpy", "scvi-tools"]
+        package: ["mudata", "spatialdata", "scirpy", "muon", "scanpy", "squidpy", "scvi-tools", "pertpy"]
 
     defaults:
       run:


### PR DESCRIPTION
I understand that every new package added to this matrix can be very noisy. However, I noticed a few failures with the latest anndata pre-release. It also caused hazard in for example pydeseq2 which was propagated to pertpy.

Oh, and you can expect me to investigate any opened issues and close them if they're not caused by anndata.

Feel free to reject!